### PR TITLE
Add repo to travis script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,5 @@ deploy:
   app:
     master: anotherlocallib
     staging: anotherlocallib-staging
+  on:
+    repo: Nkoli/anotherlocallib


### PR DESCRIPTION
Travis cannot deploy to Heroku due to stash entries error. Added the repo name to the travis script in the hopes of fixing this